### PR TITLE
Implement `/cards/` & `/cards/<id>` API endpoints

### DIFF
--- a/hanki-backend/src/main/java/com/hanki/backend/controller/CardController.java
+++ b/hanki-backend/src/main/java/com/hanki/backend/controller/CardController.java
@@ -1,8 +1,10 @@
 package com.hanki.backend.controller;
 
+import com.hanki.backend.exception.CardNotFoundException;
 import com.hanki.backend.model.Card;
 import com.hanki.backend.service.CardService;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -18,5 +20,10 @@ public class CardController {
     @GetMapping
     public Iterable<Card> getAllCards() {
         return cardService.findAll();
+    }
+
+    @GetMapping("/{id}")
+    public Card getCardById(@PathVariable Integer id) {
+        return cardService.findById(id).orElseThrow(() -> new CardNotFoundException("Card not found with id: " + id));
     }
 }

--- a/hanki-backend/src/main/java/com/hanki/backend/controller/CardController.java
+++ b/hanki-backend/src/main/java/com/hanki/backend/controller/CardController.java
@@ -1,0 +1,22 @@
+package com.hanki.backend.controller;
+
+import com.hanki.backend.model.Card;
+import com.hanki.backend.service.CardService;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/cards")
+public class CardController {
+    private final CardService cardService;
+
+    public CardController(CardService cardService) {
+        this.cardService = cardService;
+    }
+
+    @GetMapping
+    public Iterable<Card> getAllCards() {
+        return cardService.findAll();
+    }
+}

--- a/hanki-backend/src/main/java/com/hanki/backend/controller/CardController.java
+++ b/hanki-backend/src/main/java/com/hanki/backend/controller/CardController.java
@@ -3,10 +3,12 @@ package com.hanki.backend.controller;
 import com.hanki.backend.exception.CardNotFoundException;
 import com.hanki.backend.model.Card;
 import com.hanki.backend.service.CardService;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.HashMap;
+import java.util.Map;
 
 @RestController
 @RequestMapping("/cards")
@@ -25,5 +27,12 @@ public class CardController {
     @GetMapping("/{id}")
     public Card getCardById(@PathVariable Integer id) {
         return cardService.findById(id).orElseThrow(() -> new CardNotFoundException("Card not found with id: " + id));
+    }
+
+    @ExceptionHandler(CardNotFoundException.class)
+    public ResponseEntity<Map<String, String>> handleCardNotFoundException(CardNotFoundException ex) {
+        Map<String, String> response = new HashMap<>();
+        response.put("message", ex.getMessage()); // Return the exception message
+        return new ResponseEntity<>(response, HttpStatus.NOT_FOUND);
     }
 }

--- a/hanki-backend/src/main/java/com/hanki/backend/dto/CardPostDto.java
+++ b/hanki-backend/src/main/java/com/hanki/backend/dto/CardPostDto.java
@@ -1,0 +1,4 @@
+package com.hanki.backend.dto;
+
+public class CardPostDto {
+}

--- a/hanki-backend/src/main/java/com/hanki/backend/exception/CardNotFoundException.java
+++ b/hanki-backend/src/main/java/com/hanki/backend/exception/CardNotFoundException.java
@@ -1,0 +1,11 @@
+package com.hanki.backend.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.NOT_FOUND)
+public class CardNotFoundException extends RuntimeException {
+    public CardNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/hanki-backend/src/main/java/com/hanki/backend/model/Card.java
+++ b/hanki-backend/src/main/java/com/hanki/backend/model/Card.java
@@ -1,0 +1,84 @@
+package com.hanki.backend.model;
+
+import jakarta.persistence.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "card")
+public class Card {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id;
+
+    @Column(name = "front_text", nullable = false, columnDefinition = "TEXT")
+    private String frontText;
+
+    @Column(name = "back_text", nullable = false, columnDefinition = "TEXT")
+    private String backText;
+
+    @ManyToOne
+    @JoinColumn(name = "deck_id", nullable = false, foreignKey = @ForeignKey(name = "fk_card_deck"))
+    private Deck deck;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt = LocalDateTime.now();
+
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt = LocalDateTime.now();
+
+    @PreUpdate
+    protected void onUpdate() {
+        updatedAt = LocalDateTime.now();
+    }
+
+    public Integer getId() {
+        return id;
+    }
+
+    public void setId(Integer id) {
+        this.id = id;
+    }
+
+    public String getFrontText() {
+        return frontText;
+    }
+
+    public void setFrontText(String frontText) {
+        this.frontText = frontText;
+    }
+
+    public String getBackText() {
+        return backText;
+    }
+
+    public void setBackText(String backText) {
+        this.backText = backText;
+    }
+
+    public Deck getDeck() {
+        return deck;
+    }
+
+    public void setDeck(Deck deck) {
+        this.deck = deck;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(LocalDateTime createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public LocalDateTime getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public void setUpdatedAt(LocalDateTime updatedAt) {
+        this.updatedAt = updatedAt;
+    }
+
+    public Card() {}
+}

--- a/hanki-backend/src/main/java/com/hanki/backend/repository/CardRepository.java
+++ b/hanki-backend/src/main/java/com/hanki/backend/repository/CardRepository.java
@@ -1,0 +1,7 @@
+package com.hanki.backend.repository;
+
+import com.hanki.backend.model.Card;
+import org.springframework.data.repository.CrudRepository;
+
+public interface CardRepository extends CrudRepository<Card, Integer> {
+}

--- a/hanki-backend/src/main/java/com/hanki/backend/service/CardService.java
+++ b/hanki-backend/src/main/java/com/hanki/backend/service/CardService.java
@@ -1,0 +1,39 @@
+package com.hanki.backend.service;
+
+import com.hanki.backend.model.Card;
+import com.hanki.backend.repository.CardRepository;
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@Component
+public class CardService {
+    private final CardRepository cardRepository;
+
+    public CardService(CardRepository cardRepository) {
+        this.cardRepository = cardRepository;
+    }
+
+    @PostConstruct
+    public void init() {
+        System.out.println("Done constructing DeckService bean");
+    }
+
+    @PreDestroy
+    public void shutdown() {
+        System.out.println("Destroying DeckService bean");
+    }
+
+    @Transactional
+    public Iterable<Card> findAll() {
+        return cardRepository.findAll();
+    }
+
+    @Transactional
+    public Optional<Card> findById(Integer id) {
+        return cardRepository.findById(id);
+    }
+}

--- a/hanki-backend/src/test/java/com/hanki/backend/controller/CardControllerTest.java
+++ b/hanki-backend/src/test/java/com/hanki/backend/controller/CardControllerTest.java
@@ -1,0 +1,25 @@
+package com.hanki.backend.controller;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+public class CardControllerTest {
+    @Autowired
+    MockMvc mockMvc;
+
+    @Test
+    public void testGetAllCards() throws Exception {
+        mockMvc.perform(get("/cards"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$").isArray());
+    }
+}

--- a/hanki-backend/src/test/java/com/hanki/backend/controller/CardControllerTest.java
+++ b/hanki-backend/src/test/java/com/hanki/backend/controller/CardControllerTest.java
@@ -1,11 +1,18 @@
 package com.hanki.backend.controller;
 
+import com.hanki.backend.model.Card;
+import com.hanki.backend.model.Deck;
+import com.hanki.backend.service.CardService;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.web.servlet.MockMvc;
 
+import java.util.Optional;
+
+import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -16,10 +23,40 @@ public class CardControllerTest {
     @Autowired
     MockMvc mockMvc;
 
+    @Mock
+    private CardService cardService;
+
     @Test
     public void testGetAllCards() throws Exception {
         mockMvc.perform(get("/cards"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$").isArray());
+    }
+
+    @Test
+    public void testGetCardById() throws Exception {
+        // Create mock Deck
+        int existingCardId = 1;
+        Card mockCard = new Card();
+        mockCard.setId(existingCardId);
+        mockCard.setFrontText("Mock Front Text");
+        mockCard.setBackText("Mock Back Text");
+        mockCard.setDeck(new Deck());
+
+        // Mock the service method to return the mock Card created
+        when(cardService.findById(existingCardId)).thenReturn(Optional.of(mockCard));
+
+        mockMvc.perform(get("/cards/" + existingCardId))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    public void testGetCardByIdNotFound() throws Exception {
+        // Define a non-existent Card id
+        int nonExistentCardId = 99;
+
+        mockMvc.perform(get("/cards/" + nonExistentCardId))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.message").value("Card not found with id: " + nonExistentCardId));
     }
 }

--- a/setup/db-setup/init.sql
+++ b/setup/db-setup/init.sql
@@ -5,3 +5,15 @@ CREATE TABLE deck (
   name VARCHAR(255) NOT NULL,
   description TEXT NOT NULL
 );
+
+-- Creation of card table
+
+CREATE TABLE card (
+    id SERIAL PRIMARY KEY,
+    front_text TEXT NOT NULL,
+    back_text TEXT NOT NULL,
+    deck_id INT NOT NULL,
+    created_at TIMESTAMP DEFAULT NOW(),
+    updated_at TIMESTAMP DEFAULT NOW(),
+    CONSTRAINT fk_card_deck FOREIGN KEY (deck_id) REFERENCES deck(id) ON DELETE CASCADE
+);


### PR DESCRIPTION
# Changes in this PR 

This PR includes changes to implement the `/cards` & `/cards/<id>` API endpoints that allow clients to view all `Card`s & a specific `Card` with the specified `id`

# Issues Closed

This PR will close #7 