### PR TITLE
Add new workflow to automatically create PRs from develop to main

### DIFF
--- a/.github/workflows/auto-pr-to-main.yml
+++ b/.github/workflows/auto-pr-to-main.yml
@@ -1,0 +1,37 @@
+name: Auto PR from develop to main
+
+on:
+  push:
+    branches:
+      - develop
+
+jobs:
+  create-pull-request:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Set up Git
+        run: |
+          git config --global user.name "github-actions"
+          git config --global user.email "github-actions@github.com"
+
+      - name: Create Pull Request from develop to main
+        run: |
+          git fetch origin
+          git checkout develop
+          git pull origin develop
+          PR_EXISTS=$(curl -s https://api.github.com/repos/${{ github.repository }}/pulls?state=open | jq '.[] | select(.head.ref=="develop" and .base.ref=="main") | .id' || echo '')
+
+          if [ -z "$PR_EXISTS" ]; then
+            curl -X POST -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" -d '{
+              "title": "Auto PR from develop to main",
+              "head": "develop",
+              "base": "main",
+              "body": "This is an automatically created PR to merge develop into main."
+            }' "https://api.github.com/repos/${{ github.repository }}/pulls"
+          else
+            echo "Pull request already exists."
+          fi


### PR DESCRIPTION
# Changes in this PR 

This PR is raised to define a new GitHub Actions workflow that automatically raises PRs from `develop` to `main` if there are no active PRs from `develop` to `main`