### PR TITLE
Define workflow to deploy `Hanki` jar to AWS

### DIFF
--- a/.github/workflows/aws-backend-deploy.yml
+++ b/.github/workflows/aws-backend-deploy.yml
@@ -1,0 +1,43 @@
+name: Deploy Spring Boot (Gradle) to AWS
+
+on:
+  push:
+    branches:
+      - deploy
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          distribution: "temurin"
+          java-version: "17"
+          cache: "gradle"
+
+      - name: Grant execute permission for Gradle
+        run: chmod +x gradlew
+        working-directory: hanki-backend
+
+      - name: Build and Verify Compilation
+        run: ./gradlew build --no-daemon --stacktrace
+        working-directory: hanki-backend
+
+      - name: Run Tests
+        run: ./gradlew test --no-daemon --stacktrace
+        working-directory: hanki-backend
+
+      - name: Deploy to AWS Elastic Beanstalk
+        uses: einaregilsson/beanstalk-deploy@v1
+        with:
+          aws_access_key: ${{ secrets.AWS_ACCESS_KEY }}
+          aws_secret_key: ${{ secrets.AWS_SECRET_KEY }}
+          aws_region: "us-east-1"
+          application_name: "hanki-backend"
+          environment_name: "hanki-backend-env"
+          version_label: "v${{ github.run_number }}"

--- a/.github/workflows/aws-backend-deploy.yml
+++ b/.github/workflows/aws-backend-deploy.yml
@@ -35,8 +35,8 @@ jobs:
       - name: Deploy to AWS Elastic Beanstalk
         uses: einaregilsson/beanstalk-deploy@v1
         with:
-          aws_access_key: ${{ secrets.AWS_ACCESS_KEY }}
-          aws_secret_key: ${{ secrets.AWS_SECRET_KEY }}
+          aws_access_key: ${{ secrets.AWS_DEV_ACCESS_KEY }}
+          aws_secret_key: ${{ secrets.AWS_DEV_SECRET_KEY }}
           aws_region: "us-east-1"
           application_name: "hanki-backend"
           environment_name: "hanki-backend-env"


### PR DESCRIPTION
# Changes in this PR 

This PR contains changes to set up a GitHub Actions workflow that deploys the `Hanki` JAR to AWS on any pushes to the `deploy` branch

# Issue(s) closed

This PR closes #22 

