### PR TITLE
Implement JWT in Hanki backend

### DIFF
--- a/hanki-backend/build.gradle
+++ b/hanki-backend/build.gradle
@@ -29,6 +29,9 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'jakarta.validation:jakarta.validation-api'
 	implementation 'org.hibernate.validator:hibernate-validator'
+	implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
+	implementation 'io.jsonwebtoken:jjwt-impl:0.12.6'
+	implementation 'io.jsonwebtoken:jjwt-jackson:0.12.6'
 
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'

--- a/hanki-backend/src/main/java/com/hanki/backend/config/JwtFilter.java
+++ b/hanki-backend/src/main/java/com/hanki/backend/config/JwtFilter.java
@@ -1,0 +1,54 @@
+package com.hanki.backend.config;
+
+import com.hanki.backend.service.HankiUserDetailsService;
+import com.hanki.backend.service.JWTService;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.context.ApplicationContext;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Component
+public class JwtFilter extends OncePerRequestFilter {
+
+    @Autowired
+    private JWTService jwtService;
+
+    @Autowired
+    ApplicationContext context;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+        String authHeader = request.getHeader("Authorization");
+        String token = null;
+        String username = null;
+
+        if (authHeader != null && authHeader.startsWith("Bearer ")) {
+            token = authHeader.substring(7);
+            username = jwtService.extractUserName(token);
+        }
+
+        if (username != null && SecurityContextHolder.getContext().getAuthentication() == null) {
+            UserDetails userDetails = context.getBean(HankiUserDetailsService.class).loadUserByUsername(username);
+
+            if (jwtService.validateToken(token, userDetails)) {
+                UsernamePasswordAuthenticationToken authToken = new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+                authToken.setDetails(new WebAuthenticationDetailsSource()
+                        .buildDetails(request));
+                SecurityContextHolder.getContext().setAuthentication(authToken);
+            }
+        }
+
+        filterChain.doFilter(request, response);
+    }
+}

--- a/hanki-backend/src/main/java/com/hanki/backend/controller/UserController.java
+++ b/hanki-backend/src/main/java/com/hanki/backend/controller/UserController.java
@@ -14,6 +14,8 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.Map;
+
 @RestController
 @RequestMapping("/users")
 public class UserController {
@@ -31,13 +33,18 @@ public class UserController {
     }
 
     @PostMapping("/login")
-    public ResponseEntity<String> loginUser(@Valid @RequestBody UserLoginDto userLoginDto) {
-        String message = userService.verify(userLoginDto);
+    public ResponseEntity<?> loginUser(@Valid @RequestBody UserLoginDto userLoginDto) {
+        String accessToken = userService.verify(userLoginDto);
 
-        if (message.equals("Success")) {
-            return ResponseEntity.status(HttpStatus.CREATED).body(message);
+        if ("Fail".equals(accessToken)) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                    .body(Map.of("error", "Invalid credentials"));
         }
 
-        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(message);
+        Map<String, String> responseBody = Map.of(
+                "access_token", accessToken
+        );
+
+        return ResponseEntity.ok(responseBody);
     }
 }

--- a/hanki-backend/src/main/java/com/hanki/backend/controller/UserController.java
+++ b/hanki-backend/src/main/java/com/hanki/backend/controller/UserController.java
@@ -31,15 +31,13 @@ public class UserController {
     }
 
     @PostMapping("/login")
-    public ResponseEntity<UserResponseDto> loginUser(@Valid @RequestBody UserLoginDto userLoginDto) {
-        User user = userService.loginUser(userLoginDto);
+    public ResponseEntity<String> loginUser(@Valid @RequestBody UserLoginDto userLoginDto) {
+        String message = userService.verify(userLoginDto);
 
-        if (user != null) {
-            UserResponseDto userResponseDto = new UserResponseDto(user.getId(), user.getUsername(), user.getEmail());
-
-            return ResponseEntity.status(HttpStatus.CREATED).body(userResponseDto);
-        } else {
-            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(null);
+        if (message.equals("Success")) {
+            return ResponseEntity.status(HttpStatus.CREATED).body(message);
         }
+
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(message);
     }
 }

--- a/hanki-backend/src/main/java/com/hanki/backend/dto/UserLoginDto.java
+++ b/hanki-backend/src/main/java/com/hanki/backend/dto/UserLoginDto.java
@@ -10,6 +10,10 @@ public class UserLoginDto {
     @Size(max = 100, message = "Email must be at most 100 characters")
     private String email;
 
+    @NotBlank(message = "Username cannot be blank")
+    @Size(max = 100, message = "Username must be at most 50 characters")
+    private String username;
+
     @NotBlank(message = "Password is required")
     private String password;
 
@@ -19,6 +23,14 @@ public class UserLoginDto {
 
     public void setEmail(String email) {
         this.email = email;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
     }
 
     public String getPassword() {

--- a/hanki-backend/src/main/java/com/hanki/backend/security/SecurityConfig.java
+++ b/hanki-backend/src/main/java/com/hanki/backend/security/SecurityConfig.java
@@ -1,16 +1,18 @@
 package com.hanki.backend.security;
 
-import com.hanki.backend.service.UserService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.AuthenticationProvider;
 import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
 import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 
 @Configuration
@@ -20,9 +22,6 @@ public class SecurityConfig {
     @Autowired
     private UserDetailsService userDetailsService;
 
-    @Autowired
-    private UserService userService;
-
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         return http
@@ -30,7 +29,7 @@ public class SecurityConfig {
                 // disable CSRF
                 .csrf(customizer -> customizer.disable())
                 // TODO - Update the exact endpoint(s) that don't require auth
-                .authorizeHttpRequests(request -> request.requestMatchers("/users/register", "users/login").permitAll())
+                .authorizeHttpRequests(request -> request.requestMatchers("/users/register", "/users/login").permitAll())
                 // all other endpoints require auth
                 .authorizeHttpRequests(request -> request.anyRequest().authenticated())
                 // to allow requests via browser
@@ -45,7 +44,8 @@ public class SecurityConfig {
     @Bean
     public AuthenticationProvider authenticationProvider() {
         DaoAuthenticationProvider provider = new DaoAuthenticationProvider();
-        provider.setPasswordEncoder(userService.getEncoder());
+        // TODO - Abstract out strength value to properties
+        provider.setPasswordEncoder(new BCryptPasswordEncoder(12));
         provider.setUserDetailsService(userDetailsService);
 
         return provider;

--- a/hanki-backend/src/main/java/com/hanki/backend/security/SecurityConfig.java
+++ b/hanki-backend/src/main/java/com/hanki/backend/security/SecurityConfig.java
@@ -50,4 +50,9 @@ public class SecurityConfig {
 
         return provider;
     }
+
+    @Bean
+    public AuthenticationManager authenticationManager(AuthenticationConfiguration config) throws Exception {
+        return config.getAuthenticationManager();
+    }
 }

--- a/hanki-backend/src/main/java/com/hanki/backend/security/SecurityConfig.java
+++ b/hanki-backend/src/main/java/com/hanki/backend/security/SecurityConfig.java
@@ -1,5 +1,6 @@
 package com.hanki.backend.security;
 
+import com.hanki.backend.config.JwtFilter;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -14,6 +15,7 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
 @EnableWebSecurity
@@ -21,6 +23,9 @@ public class SecurityConfig {
 
     @Autowired
     private UserDetailsService userDetailsService;
+
+    @Autowired
+    private JwtFilter jwtFilter;
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
@@ -38,6 +43,7 @@ public class SecurityConfig {
                 .httpBasic(Customizer.withDefaults())
                 .sessionManagement(session ->
                         session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class)
                 .build();
     }
 

--- a/hanki-backend/src/main/java/com/hanki/backend/service/JWTService.java
+++ b/hanki-backend/src/main/java/com/hanki/backend/service/JWTService.java
@@ -1,0 +1,50 @@
+package com.hanki.backend.service;
+
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.stereotype.Service;
+
+import javax.crypto.KeyGenerator;
+import javax.crypto.SecretKey;
+import java.security.Key;
+import java.security.NoSuchAlgorithmException;
+import java.util.Base64;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+
+@Service
+public class JWTService {
+
+    private String secretKey;
+
+    public JWTService() {
+        try {
+            KeyGenerator keyGen = KeyGenerator.getInstance("HmacSHA256");
+            SecretKey sk = keyGen.generateKey();
+            secretKey = Base64.getUrlEncoder().withoutPadding().encodeToString(sk.getEncoded());
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public String generateToken(String username) {
+        Map<String, Object> claims = new HashMap<>();
+
+        return Jwts.builder()
+                .claims()
+                .add(claims)
+                .subject(username)
+                .issuedAt(new Date(System.currentTimeMillis()))
+                .expiration(new Date(System.currentTimeMillis() + 60 * 60 * 30))
+                .and()
+                .signWith(getKey())
+                .compact();
+    }
+
+    private Key getKey() {
+        byte[]  keyBytes = Decoders.BASE64URL.decode(secretKey);
+        return Keys.hmacShaKeyFor(keyBytes);
+    }
+}

--- a/hanki-backend/src/main/java/com/hanki/backend/service/JWTService.java
+++ b/hanki-backend/src/main/java/com/hanki/backend/service/JWTService.java
@@ -1,18 +1,20 @@
 package com.hanki.backend.service;
 
+import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.security.Keys;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Service;
 
 import javax.crypto.KeyGenerator;
 import javax.crypto.SecretKey;
-import java.security.Key;
 import java.security.NoSuchAlgorithmException;
 import java.util.Base64;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.function.Function;
 
 @Service
 public class JWTService {
@@ -43,8 +45,39 @@ public class JWTService {
                 .compact();
     }
 
-    private Key getKey() {
+    private SecretKey getKey() {
         byte[]  keyBytes = Decoders.BASE64URL.decode(secretKey);
         return Keys.hmacShaKeyFor(keyBytes);
+    }
+
+    public String extractUserName(String token) {
+        // extract the username from jwt token
+        return extractClaim(token, Claims::getSubject);
+    }
+
+    private <T> T extractClaim(String token, Function<Claims, T> claimResolver) {
+        final Claims claims = extractAllClaims(token);
+        return claimResolver.apply(claims);
+    }
+
+    private Claims extractAllClaims(String token) {
+        return Jwts.parser()
+                .verifyWith(getKey())
+                .build()
+                .parseSignedClaims(token)
+                .getPayload();
+    }
+
+    public boolean validateToken(String token, UserDetails userDetails) {
+        final String userName = extractUserName(token);
+        return (userName.equals(userDetails.getUsername()) && !isTokenExpired(token));
+    }
+
+    private boolean isTokenExpired(String token) {
+        return extractExpiration(token).before(new Date());
+    }
+
+    private Date extractExpiration(String token) {
+        return extractClaim(token, Claims::getExpiration);
     }
 }

--- a/hanki-backend/src/main/java/com/hanki/backend/service/UserService.java
+++ b/hanki-backend/src/main/java/com/hanki/backend/service/UserService.java
@@ -21,6 +21,9 @@ public class UserService {
     @Autowired
     AuthenticationManager authManager;
 
+    @Autowired
+    JWTService jwtService;
+
     // TODO - Abstract out strength value to properties
     private BCryptPasswordEncoder encoder = new BCryptPasswordEncoder(12);
 
@@ -36,13 +39,13 @@ public class UserService {
     }
 
     public String verify(UserLoginDto userLoginDto) {
-        String message = "Success";
+        String message = "Fail";
 
         try {
             Authentication authentication =
                     authManager.authenticate(new UsernamePasswordAuthenticationToken(userLoginDto.getUsername(), userLoginDto.getPassword()));
             if (authentication.isAuthenticated()) {
-                return message;
+                return jwtService.generateToken(userLoginDto.getUsername());
             }
         } catch (AuthenticationException e) {
             message = "Fail";

--- a/hanki-backend/src/main/java/com/hanki/backend/service/UserService.java
+++ b/hanki-backend/src/main/java/com/hanki/backend/service/UserService.java
@@ -5,6 +5,10 @@ import com.hanki.backend.dto.UserPostDto;
 import com.hanki.backend.model.User;
 import com.hanki.backend.repository.UserRepository;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -14,6 +18,10 @@ public class UserService {
     @Autowired
     UserRepository userRepository;
 
+    @Autowired
+    AuthenticationManager authManager;
+
+    // TODO - Abstract out strength value to properties
     private BCryptPasswordEncoder encoder = new BCryptPasswordEncoder(12);
 
     public User registerUser(UserPostDto userPostDto) {
@@ -25,6 +33,22 @@ public class UserService {
         // TODO - check for presence of combination of username & password
 
         return userRepository.save(user);
+    }
+
+    public String verify(UserLoginDto userLoginDto) {
+        String message = "Success";
+
+        try {
+            Authentication authentication =
+                    authManager.authenticate(new UsernamePasswordAuthenticationToken(userLoginDto.getUsername(), userLoginDto.getPassword()));
+            if (authentication.isAuthenticated()) {
+                return message;
+            }
+        } catch (AuthenticationException e) {
+            message = "Fail";
+        }
+
+        return message;
     }
 
     public User loginUser(UserLoginDto userLoginDto) {


### PR DESCRIPTION
# Changes in this PR 

This PR is raised to implement changes to support JWT in the `Hanki` Spring Boot backend

## Implementation of JWT 

To support the implementation of JWT, these changes were required:

- Adding of the `jjwt` libraries in `build.gradle`
- Refactoring the `/login` API endpoint to return the access token
- Defining a `JWTService` class to implement the related `JWT` logic
- Updating the `SecurityFilterChain` in `SecurityConfig` to include the `JWTFilter` before the `UsernamePasswordAuthenticationFilter` 

